### PR TITLE
Twitter api v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ matchwords.txt
 __pycache__/*
 *.db
 ttnconfig/*
+*.egg-info

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,9 @@
-beautifulsoup4==4.7.1
-bs4==0.0.1
-feedparser==5.2.1
+beautifulsoup4==4.12.2
+feedparser==6.0.10
 future==0.17.1
 html2text==2018.1.9
-Pillow==6.2.0
+Pillow==8.4
 pyaml==18.11.0
 readability-lxml==0.7
-requests==2.21.0
+requests==2.31.0
 twython==3.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ Pillow==8.4
 pyaml==18.11.0
 readability-lxml==0.7
 requests==2.31.0
-twython==3.7.0
+tweepy==4.14.0

--- a/trackthenews/core.py
+++ b/trackthenews/core.py
@@ -213,7 +213,7 @@ def config_twitter(config):
         if replace.lower() in ['n','no']:
             return config
 
-    input("Create a new Twitter app at https://apps.twitter.com/app/new to post matching stories. For this step, you can be logged in as yourself or with the posting account, if they're different. Fill out Name, Description, and Website with values meaningful to you. These are not used in trackthenews config but may be publicly visible. Then click the \"Keys and Access Tokens\" tab. ")
+    input("Create a new Twitter app at https://developer.twitter.com/en/portal/projects-and-apps to post matching stories. For this step, you can be logged in as yourself or with the posting account, if they're different. Fill out Name, Description, and Website with values meaningful to you. These are not used in trackthenews config but may be publicly visible. Then click the \"Keys and Access Tokens\" tab. ")
 
     api_key = input("Enter the provided API key: ")
     api_secret = input("Enter the provided API secret: ")


### PR DESCRIPTION
This PR should get all trackthenews-based bots working again with no changes to their configuration. We update tweet creation to use the now-required v2 API by switching from Twython to Tweepy.

I also included a few dependency upgrades I needed to get the package working on python 3.9