### PR TITLE
Remove ipdb

### DIFF
--- a/trackthenews/core.py
+++ b/trackthenews/core.py
@@ -145,13 +145,8 @@ class Article:
         content = "{}{} {}".format(source, title, self.url)
 
         twitter = get_twitter_client()
-        try:
-            twitter.create_tweet(text=content, media_ids=media_ids)
-        except tweepy.errors.TweepyException as e:
-            import ipdb
 
-            ipdb.set_trace()
-            pass
+        twitter.create_tweet(text=content, media_ids=media_ids)
 
         self.tweeted = True
 


### PR DESCRIPTION
I removed error handling altogether. There wasn't any in xor's previous versions of the code and I think at this point if the script fails to tweet we want it to fail loudly.

At some point we'll want to integrate logging and record failures while allowing the script to continue