### PR TITLE
Enable blocklist to match on individual paragraphs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ All articles are recorded in a sqlite database.
 
 ### Advanced feature: blocklist
 
-In some cases, you may wish to suppress articles from being posted, even though they would otherwise match. You can do so by writing a new function, `check`, and placing it in a file named `blocklist.py` in the configuration directory. `check` takes an Article (and so has access to its `outlet`, `title`, and `url`) and should return `true` for any article that should be skipped.
+In some cases, you may wish to suppress articles from being posted, even though they would otherwise match. You can do so by writing two new functions, `check_article` and `check_paragraph`, and placing them in a file named `blocklist.py` in the configuration directory:
+- `check_article` takes an Article (and so has access to its `outlet`, `title`, and `url`) and should return `True` for any article that should be skipped in its entirety.
+- `check_paragraph` takes an Article and an individual matching paragraph and should return `True` for any paragraph that should be skipped (if other paragraphs match, the article will still be posted, but without the skipped paragraphs).
 
 ## Development
 

--- a/trackthenews/core.py
+++ b/trackthenews/core.py
@@ -81,13 +81,15 @@ class Article:
         self.clean(http_session)
         plaintext_grafs = self.plaintext.split("\n")
 
-        if blocklist_loaded and blocklist.check(self):
+        if blocklist_loaded and blocklist.check_article(self):
             pass
         else:
             for graf in plaintext_grafs:
                 if any(word.lower() in graf.lower() for word in matchwords) or any(
                     word in graf for word in matchwords_case_sensitive
                 ):
+                    if blocklist_loaded and blocklist.check_paragraph(self, graf):
+                        continue
                     self.matching_grafs.append(graf)
 
     def prepare_images(self, square):


### PR DESCRIPTION
This allows us to take better control over false positives.

NB: This is a breaking change for deployments that use a `blocklist.py` in the old format. For FOIAFeed, I'll submit a separate PR to update the blocklist.

Resolves #59 